### PR TITLE
Show precise finish time on race finish

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -121,3 +121,6 @@ run/
 .factorypath
 .classpath
 .settings
+
+# Testing
+test/

--- a/.gitignore
+++ b/.gitignore
@@ -122,5 +122,3 @@ run/
 .classpath
 .settings
 
-# Testing
-test/

--- a/flake.nix
+++ b/flake.nix
@@ -31,7 +31,7 @@
         yesboats = pkgs.callPackage
           ({ lib, maven, jdk17_headless }: maven.buildMavenPackage rec {
             pname = "YesBoats";
-            version = "1.5.2";
+            version = "1.5.3";
 
             src = ./.;
 

--- a/flake.nix
+++ b/flake.nix
@@ -21,7 +21,7 @@
         default = pkgs.mkShell {
           packages = with pkgs; [
             maven
-            jdk17_headless
+            jdk17
           ];
         };
       });

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
   <groupId>rocks.learnercouncil</groupId>
   <artifactId>YesBoats</artifactId>
-  <version>1.5.2</version>
+  <version>1.5.3</version>
   <packaging>jar</packaging>
 
   <name>Yesboats</name>

--- a/src/main/java/rocks/learnercouncil/yesboats/YesBoatsPlayer.java
+++ b/src/main/java/rocks/learnercouncil/yesboats/YesBoatsPlayer.java
@@ -15,6 +15,7 @@ import rocks.learnercouncil.yesboats.arena.Arena;
 import rocks.learnercouncil.yesboats.arena.ArenaScoreboard;
 import rocks.learnercouncil.yesboats.arena.DebugPath;
 
+import java.text.DecimalFormat;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Objects;
@@ -158,7 +159,8 @@ public class YesBoatsPlayer {
 
         double totalSeconds = ((double) (System.currentTimeMillis() - time)) / 1000;
         int minutes = (int) totalSeconds / 60;
-        int seconds = (int) totalSeconds % 60;
+        double seconds = Math.floor((totalSeconds % 60) * 1000) / 1000;
+        DecimalFormat df = new DecimalFormat("00.00#");
         String s = "th";
         int lastDigit = currentPlace % 10;
         if(lastDigit == 1 && currentPlace != 11)
@@ -170,7 +172,7 @@ public class YesBoatsPlayer {
         final String suffix = s;
         player.sendMessage(ChatColor.DARK_AQUA + "[YesBoats] "
                 + ChatColor.AQUA + "You have completed the race with a time of "
-                + ChatColor.YELLOW + minutes + ":" + (seconds < 10 ? "0"+seconds : seconds)
+                + ChatColor.YELLOW + minutes + ":" + df.format(seconds).toString()
                 + ChatColor.AQUA + ". That puts you in "
                 + ChatColor.YELLOW + currentPlace + suffix
                 + ChatColor.AQUA + " place."


### PR DESCRIPTION
Changed the "You have completed the race with a time of 1:23." message at the end to give more precision, now showing milliseconds. (i.e 1:23.456) Allows for better comparison of completed race times.